### PR TITLE
修复强解_lastTypeRange导致的崩溃

### DIFF
--- a/BSText/BSTextView.swift
+++ b/BSText/BSTextView.swift
@@ -3813,7 +3813,7 @@ open class BSTextView: UIScrollView, UITextInput, UITextInputTraits, UIScrollVie
         if text == "" {
             return
         }
-        if !NSEqualRanges(_lastTypeRange!, _selectedTextRange.asRange) {
+        if !NSEqualRanges(_lastTypeRange ?? NSMakeRange(0, 0), _selectedTextRange.asRange) {
             _saveToUndoStack()
             _resetRedoStack()
         }


### PR DESCRIPTION
XCode Version 13.1 (13A1030d)
iOS 15.0

初始化一个TextView 后首次输入会因为强解为nil的_lastTypeRange而导致崩溃