### PR TITLE
Fix #19: Fix memory leak in TextDebugOption and make BSTextView init public

### DIFF
--- a/BSText/BSTextView.swift
+++ b/BSText/BSTextView.swift
@@ -2914,7 +2914,7 @@ open class BSTextView: UIScrollView, UITextInput, UITextInputTraits, UIScrollVie
     
     // MARK: - Public
     
-    override init(frame: CGRect) {
+    public override init(frame: CGRect) {
         super.init(frame: frame)
         
         tokenizer = UITextInputStringTokenizer(textInput: self)

--- a/BSText/Component/TextDebugOption.swift
+++ b/BSText/Component/TextDebugOption.swift
@@ -152,7 +152,14 @@ fileprivate var sharedDebugTargets = NSPointerArray()
     public class func remove(_ target: TextDebugTarget?) {
         
         sharedDebugLock.wait()
-        sharedDebugTargets.addObject(target)
+        // Find and remove the target from the array
+        for i in (0..<sharedDebugTargets.count).reversed() {
+            if let obj = sharedDebugTargets.object(at: i) as? TextDebugTarget,
+               obj === target {
+                sharedDebugTargets.removePointer(at: i)
+                break
+            }
+        }
         sharedDebugLock.signal()
     }
     


### PR DESCRIPTION
## Summary
Fixes #19 - Fixes memory leak and subclassing issues

## Changes
1. **Fix memory leak in TextDebugOption.remove()**
   - The remove() method was incorrectly using addObject() instead of actually removing the target
   - Now properly finds and removes the target from sharedDebugTargets array

2. **Fix BSTextView subclassing**
   - Changed override init(frame:) to public override init(frame:) to allow subclassing

## Testing
- [ ] Memory leak no longer occurs when creating/destroying BSTextView/BSLabel in cells
- [ ] BSTextView can now be properly subclassed

## Related Issues
Closes #19