### PR TITLE
Fix/issue 36 async memory

### DIFF
--- a/BSText/BSLabel.swift
+++ b/BSText/BSLabel.swift
@@ -1219,6 +1219,7 @@ open class BSLabel: UIView, TextDebugTarget, TextAsyncLayerDelegate, NSSecureCod
     open func prepareForReuse() {
         // Cancel any pending async display operations
         (layer as? TextAsyncLayer)?.displaysAsynchronously = false
+        layer.setNeedsDisplay()
         layer.contents = nil
         innerLayout = nil
         shrinkInnerLayout = nil

--- a/BSText/BSLabel.swift
+++ b/BSText/BSLabel.swift
@@ -1214,6 +1214,16 @@ open class BSLabel: UIView, TextDebugTarget, TextAsyncLayerDelegate, NSSecureCod
         longPressTimer?.invalidate()
     }
     
+    /// Prepares the label for reuse in a cell.
+    /// Call this method when the label is being reused in a table view or collection view cell.
+    open func prepareForReuse() {
+        // Cancel any pending async display operations
+        (layer as? TextAsyncLayer)?.displaysAsynchronously = false
+        layer.contents = nil
+        innerLayout = nil
+        shrinkInnerLayout = nil
+    }
+    
     override open class var layerClass: AnyClass {
         return TextAsyncLayer.self
     }

--- a/BSText/Utility/TextAsyncLayer.swift
+++ b/BSText/Utility/TextAsyncLayer.swift
@@ -164,14 +164,16 @@ public class TextAsyncLayer: CALayer {
                     task?.display!(context, size, isCancelled)
                 }
                 if isCancelled() {
-                    DispatchQueue.main.async(execute: {
+                    DispatchQueue.main.async(execute: { [weak self] in
+                        guard let self = self else { return }
                         if ((task?.didDisplay) != nil) {
                             task?.didDisplay!(self, false)
                         }
                     })
                     return
                 }
-                DispatchQueue.main.async(execute: {
+                DispatchQueue.main.async(execute: { [weak self] in
+                    guard let self = self else { return }
                     if isCancelled() {
                         if ((task?.didDisplay) != nil) {
                             task?.didDisplay!(self, false)


### PR DESCRIPTION
## Summary
This PR fixes the memory leak issue with `_displayAsync` when BSLabel is used in table view or collection view cells.

## Problem
When BSLabel with `displaysAsynchronously = true` is used inside cells, the memory is not properly released when cells are reused. This is caused by:

1. **Retain cycles**: The async display closure captures `self` strongly, preventing proper deallocation
2. **Missing cleanup**: No method to properly cancel pending async operations when cells are reused

## Changes

### Fix 1: Prevent Retain Cycles in TextAsyncLayer

Modified `TextAsyncLayer.swift` to use `[weak self]` in `DispatchQueue.main.async` closures:

```swift
// Before
DispatchQueue.main.async(execute: {
    self.contents = image.cgImage
})

// After
DispatchQueue.main.async(execute: { [weak self] in
    guard let self = self else { return }
    self.contents = image.cgImage
})
```

### Fix 2: Add prepareForReuse() Method

Added `prepareForReuse()` method to BSLabel for proper cell reuse cleanup:

```swift
open func prepareForReuse() {
    (layer as? TextAsyncLayer)?.displaysAsynchronously = false
    layer.contents = nil
    innerLayout = nil
    shrinkInnerLayout = nil
}
```

## Code Review Notes
- The existing `deinit` in `TextAsyncLayer` already calls `sentinel.increase()` to cancel pending operations
- The fix uses standard Swift memory management patterns (`[weak self]` with `guard let`)
- The `prepareForReuse()` method follows Apple's cell reuse pattern

## Testing Needed
⚠️ **Note**: This PR needs manual testing as automated tests are not available in the current environment.

Recommended test cases:
1. Create a table view with BSLabel cells
2. Enable `displaysAsynchronously = true` on labels
3. Scroll rapidly and check memory usage with Instruments
4. Verify `prepareForReuse()` is called properly in cell reuse

## Related Issues
Closes #36